### PR TITLE
Improvements for deploying with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Make following changes to that package's `mix.exs`:
   defp hex() do
     [
       api_url: "http://localhost:4000/api/repos/test_repo",
-      # make sure to change it, see `auth_token` in config/releases.exs
+      # make sure to change it, see `auth_token` in config/runtime.exs
       api_key: "secret"
     ]
   end
@@ -146,7 +146,7 @@ configuration:
     #{
       name => <<"test_repo">>,
 
-      %% make sure to change it, see `auth_token` in config/releases.exs
+      %% make sure to change it, see `auth_token` in config/runtime.exs
       api_key => <<"secret">>,
       api_url => <<"http://localhost:4000/api/repos/test_repo">>,
       api_repository => undefined,
@@ -210,15 +210,34 @@ And start it:
     _build/prod/rel/mini_repo/bin/mini_repo start
 
 As you can see, some configuration can be set by adjusting system environment variables,
-see [`config/releases.exs`](config/releases.exs)
-
-**Warning**: MiniRepo by default has very basic authorization uses pre-generated
-public/private keys for repository signing.
-Make sure to generate your own public/private keys and consider adding authentication
-that makes sense in your organization.
+see [`config/runtime.exs`](config/runtime.exs)
 
 Also, see [`mix help release`](https://hexdocs.pm/mix/Mix.Tasks.Release.html?) for general
 information on Elixir releases.
+
+**Warning**: Make sure to generate your own private/public key for signing, an auth token,
+and add additional authentication that makes sense in your organization.
+
+### Deployment with Docker
+
+MiniRepo ships with a [`Dockerfile`](Dockerfile) that you may use to build your Docker container.
+
+You may also use a published Docker image
+[`wojtekmach/mini_repo:latest`](https://hub.docker.com/r/wojtekmach/mini_repo) like this:
+
+    docker run \
+      -e MINI_REPO_AUTH_TOKEN=secret \
+      -e MINI_REPO_STORE_ROOT=/data \
+      -v $PWD/data:/data \
+      -v $PWD/config:/app/config \
+      -p 4000:4000 \
+      wojtekmach/mini_repo:latest
+
+Note, we mount `data` volume so that repository data is persisted between container runs. We mount
+`config` volume so that we can adjust the [`config/runtime.exs`](config/runtime.exs) file.
+
+**Warning**: Make sure to generate your own private/public key for signing, an auth token,
+and add additional authentication that makes sense in your organization.
 
 ## More information
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,1 +1,1 @@
-# See config/releases.exs
+# Put built-time prod configuration here. See runtime.exs for runtime config.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,3 +1,10 @@
+# We use a custom config/runtime.exs (instead of default config/releases.exs) file so that when
+# running in a Docker container we can easily mount volume to overwrite the config (without
+# changing the docker image):
+#
+#     docker run -v $PWD/some_config:/app/config mini_test:latest
+#
+
 import Config
 
 config :mini_repo,
@@ -26,7 +33,8 @@ auth_token =
         "Xyf..."
     """
 
-store = {MiniRepo.Store.Local, root: {:mini_repo, "data"}}
+root = System.get_env("MINI_REPO_STORE_ROOT") || {:mini_repo, "data"}
+store = {MiniRepo.Store.Local, root: root}
 
 config :mini_repo,
   auth_token: System.fetch_env!("MINI_REPO_AUTH_TOKEN"),

--- a/lib/mini_repo/store/s3.ex
+++ b/lib/mini_repo/store/s3.ex
@@ -12,7 +12,7 @@ defmodule MiniRepo.Store.S3 do
       
   ## Usage
 
-  Add to `config/releases.exs`:
+  Add to `config/runtime.exs`:
 
       config :ex_aws,
         access_key_id: System.fetch_env!("MINI_REPO_S3_ACCESS_KEY_ID"),

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,8 @@ defmodule MiniRepo.MixProject do
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-      aliases: aliases()
+      aliases: aliases(),
+      releases: releases()
     ]
   end
 
@@ -39,5 +40,23 @@ defmodule MiniRepo.MixProject do
     [
       test: ["test --no-start"]
     ]
+  end
+
+  defp releases() do
+    [
+      mini_repo: [
+        steps: [:assemble, &copy_runtime_exs/1],
+        config_providers: [{Config.Reader, {:system, "RELEASE_ROOT", "/config/runtime.exs"}}]
+      ]
+    ]
+  end
+
+  # see config/runtime.exs
+  defp copy_runtime_exs(release) do
+    File.mkdir!(Path.join(release.path, "config"))
+    local_path = Path.join([__DIR__, "config", "runtime.exs"])
+    release_path = Path.join([release.path, "config", "runtime.exs"])
+    File.cp!(local_path, release_path)
+    release
   end
 end

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Testing script for running with Docker
+set -e
+
+docker build . -t mini_repo:latest
+docker run \
+  -e MINI_REPO_AUTH_TOKEN=secret \
+  -e MINI_REPO_STORE_ROOT=/data \
+  -v $PWD/data:/data \
+  -v $PWD/config:/app/config \
+  -p 4000:4000 \
+  mini_repo:latest


### PR DESCRIPTION
* Rename `config/releases.exs` to `config/runtime.exs` and add release step that copies `config/runtime.exs` to `RELEASE_ROOT/config/runtime.exs`.

  This way we can easily overwrite configuration by mounting a config volume when starting the container.

* Add `MINI_REPO_STORE_ROOT` env variable that can be used to overwrite the root for `MiniRepo.Store.Local` files. If not set, the default: `{:mini_repo, "data"}` (which works like `Plug.Static` `:from`) is still used.

* Add section about deploying with Docker

cc @ericmj @supersimple @tsloughter