### PR TITLE
Feature/server on demand

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,8 +1,8 @@
 import Config
 
 config :mini_repo,
-  port: 4444,
-  url: "http://localhost:4444"
+  port: 4000,
+  url: "http://localhost:4000"
 
 store = {MiniRepo.Store.Local, root: {:mini_repo, "data"}}
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,8 +1,8 @@
 import Config
 
 config :mini_repo,
-  port: 4000,
-  url: "http://localhost:4000"
+  port: 4444,
+  url: "http://localhost:4444"
 
 store = {MiniRepo.Store.Local, root: {:mini_repo, "data"}}
 
@@ -20,8 +20,9 @@ config :mini_repo,
       upstream_url: "https://repo.hex.pm",
 
       # only mirror following packages
-      only: ~w(decimal),
-
+      on_demand: true,
+      # only: ~w[decimal],
+      
       # 5min
       sync_interval: 5 * 60 * 1000,
       sync_opts: [max_concurrency: 1],

--- a/lib/mini_repo/api_router.ex
+++ b/lib/mini_repo/api_router.ex
@@ -77,7 +77,7 @@ defmodule MiniRepo.APIRouter do
 
   get "/repos/hexpm_mirror/packages/:name" do
     if is_configured_on_demand?() do
-      MiniRepo.Mirror.ServerOnDemand.fetch_if_not_exist(name)
+      MiniRepo.Mirror.ServerOnDemand.fetch_package_if_not_exist(name)
     end
 
     with {:ok, data_path} <- get_data_dir(:hexpm_mirror),
@@ -95,12 +95,16 @@ defmodule MiniRepo.APIRouter do
   end
 
   get "/repos/hexpm_mirror/tarballs/:tarball" do
-    name =
+    tb =
       String.split(tarball, "-")
-      |> Enum.at(0)
+
+      name = Enum.at(tb, 0)
+      version = 
+      Enum.at(tb, 1)
+      |> String.replace(".tar", "")
 
     if is_configured_on_demand?() do
-      MiniRepo.Mirror.ServerOnDemand.fetch_if_not_exist(name)
+      MiniRepo.Mirror.ServerOnDemand.fetch_tarball_if_not_exist(name, version)
     end
 
     with {:ok, data_path} <- get_data_dir(:hexpm_mirror),

--- a/lib/mini_repo/api_router.ex
+++ b/lib/mini_repo/api_router.ex
@@ -84,7 +84,8 @@ defmodule MiniRepo.APIRouter do
          package_path <-
            Path.join(
              Application.app_dir(:mini_repo),
-             "#{data_path}/repos/hexpm_mirror/packages/#{name}"
+            #  "#{data_path}/repos/hexpm_mirror/packages/#{name}"
+             "#{data_path}/repos/hexpm_mirror/names"
            ),
          true <- File.exists?(package_path) do
       send_file(conn, 200, package_path)
@@ -116,6 +117,83 @@ defmodule MiniRepo.APIRouter do
         send_resp(conn, 404, "not found")
     end
   end
+
+  get "/repos/:repo/packages/:name" do
+    with {:ok, data_path} <- get_data_dir(String.to_atom(repo)),
+         package_path <-
+           Path.join(
+             Application.app_dir(:mini_repo),
+             "#{data_path}/repos/#{repo}/packages/#{name}"
+           )
+          do
+      file = File.exists?(package_path)
+      send_file(conn, 200, package_path)
+    else
+      e ->
+        send_resp(conn, 404, "name: #{name}, repo: #{repo} not found")
+    end
+  end
+
+  get "/repos/:repo/tarballs/:tarball" do
+    with {:ok, data_path} <- get_data_dir(String.to_atom(repo)),
+         tarbal_path <-
+           Path.join(
+             Application.app_dir(:mini_repo),
+             "#{data_path}/repos/#{repo}/tarballs/#{tarball}"
+           ),
+         true <- File.exists?(tarbal_path) do
+      send_file(conn, 200, tarbal_path)
+    else
+      _ ->
+        send_resp(conn, 404, "repo: #{repo}, tarbal: #{tarball} not found")
+    end
+  end
+
+  get "/repos/:repo/names/" do
+    with {:ok, data_path} <- get_data_dir(String.to_atom(repo)),
+         names_path <-
+           Path.join(
+             Application.app_dir(:mini_repo),
+             "#{data_path}/repos/#{repo}/names/"
+           ),
+         true <- File.exists?(names_path) do
+      send_file(conn, 200, names_path)
+    else
+      _ ->
+        send_resp(conn, 404, "not found")
+    end
+  end
+
+  get "/repos/:repo/versions/" do
+    with {:ok, data_path} <- get_data_dir(String.to_atom(repo)),
+         versions_path <-
+           Path.join(
+             Application.app_dir(:mini_repo),
+             "#{data_path}/repos/#{repo}/versions/"
+           ),
+         true <- File.exists?(versions_path) do
+      send_file(conn, 200, versions_path)
+    else
+      _ ->
+        send_resp(conn, 404, "not found")
+    end
+  end
+
+  get "/repos/:repo/docs/:tarball" do
+    with {:ok, data_path} <- get_data_dir(String.to_atom(repo)),
+         docs_path <-
+           Path.join(
+             Application.app_dir(:mini_repo),
+             "#{data_path}/repos/#{repo}/docs/#{tarball}"
+           ),
+         true <- File.exists?(docs_path) do
+      send_file(conn, 200, docs_path)
+    else
+      _ ->
+        send_resp(conn, 404, "not found")
+    end
+  end
+
 
   match _ do
     send_resp(conn, 404, "not found")

--- a/lib/mini_repo/api_router.ex
+++ b/lib/mini_repo/api_router.ex
@@ -74,6 +74,14 @@ defmodule MiniRepo.APIRouter do
     end
   end
 
+  get "/repos/:repo/packages/:name" do
+    send_file(conn, 200, Path.join(Application.app_dir(:mini_repo), "data/repos/#{repo}/packages/#{name}"))
+  end
+
+  get  "/repos/:repo/tarballs/:tarball" do
+    send_file(conn, 200, Path.join(Application.app_dir(:mini_repo), "data/repos/#{repo}/tarballs/#{tarball}"))
+  end
+
   match _ do
     send_resp(conn, 404, "not found")
   end

--- a/lib/mini_repo/api_router.ex
+++ b/lib/mini_repo/api_router.ex
@@ -84,8 +84,7 @@ defmodule MiniRepo.APIRouter do
          package_path <-
            Path.join(
              Application.app_dir(:mini_repo),
-            #  "#{data_path}/repos/hexpm_mirror/packages/#{name}"
-             "#{data_path}/repos/hexpm_mirror/names"
+             "#{data_path}/repos/hexpm_mirror/packages/#{name}"
            ),
          true <- File.exists?(package_path) do
       send_file(conn, 200, package_path)

--- a/lib/mini_repo/application.ex
+++ b/lib/mini_repo/application.ex
@@ -36,15 +36,19 @@ defmodule MiniRepo.Application do
 
   defp repositories(config) do
     for {name, options} <- Keyword.fetch!(config, :repositories) do
-      if options[:upstream_url] do
-        struct!(MiniRepo.Mirror, [name: to_string(name)] ++ options)
-      else
-        struct!(MiniRepo.Repository, [name: to_string(name)] ++ options)
+      cond do
+        !is_nil(options[:upstream_url]) and !is_nil(options[:on_demand]) -> struct!(MiniRepo.MirrorOnDemand, [name: to_string(name)] ++ options)
+        options[:upstream_url] -> struct!(MiniRepo.Mirror, [name: to_string(name)] ++ options)
+        true ->struct!(MiniRepo.Repository, [name: to_string(name)] ++ options)
       end
     end
   end
 
   defp repository_specs(repos), do: Enum.map(repos, &repository_spec/1)
+
+
+  defp repository_spec(%MiniRepo.MirrorOnDemand{} = repo),
+    do: {MiniRepo.Mirror.ServerOnDemand, mirror: repo, name: String.to_atom(repo.name)}
 
   defp repository_spec(%MiniRepo.Mirror{} = repo),
     do: {MiniRepo.Mirror.Server, mirror: repo, name: String.to_atom(repo.name)}

--- a/lib/mini_repo/endpoint.ex
+++ b/lib/mini_repo/endpoint.ex
@@ -5,9 +5,9 @@ defmodule MiniRepo.Endpoint do
 
   plug Plug.Logger
 
-  plug Plug.Static,
-    at: "/repos",
-    from: {:mini_repo, "data/repos"}
+  # plug Plug.Static,
+  #   at: "/repos",
+  #   from: {:mini_repo, "data/repos"}
 
   plug MiniRepo.APIAuth
   plug MiniRepo.APIRouter, builder_opts()

--- a/lib/mini_repo/mirror/server_on_demand.ex
+++ b/lib/mini_repo/mirror/server_on_demand.ex
@@ -207,9 +207,6 @@ defmodule MiniRepo.Mirror.ServerOnDemand do
         |> Map.merge(created)
       end)
 
-    require IEx
-    IEx.pry()
-
     RegistryBackup.save(mirror)
     mirror
   end

--- a/lib/mini_repo/mirror/server_on_demand.ex
+++ b/lib/mini_repo/mirror/server_on_demand.ex
@@ -104,8 +104,9 @@ defmodule MiniRepo.Mirror.ServerOnDemand do
 
   @impl true
   def handle_call({:put_package, name}, _from, mirror) do
+    # TODO: Make this flow better
     config = get_config_from_mirror(mirror)
-    diff = diff_packages(mirror, config, [name])
+    {:ok, diff} = diff_packages([name], mirror, config)
     created = sync_created_packages(mirror, config, diff)
 
     mirror =

--- a/lib/mini_repo/mirror/server_on_demand.ex
+++ b/lib/mini_repo/mirror/server_on_demand.ex
@@ -1,0 +1,272 @@
+defmodule MiniRepo.Mirror.ServerOnDemand do
+    @moduledoc false
+  
+    use GenServer
+    require Logger
+    alias MiniRepo.{RegistryDiff, RegistryBackup}
+  
+    @default_sync_opts [ordered: false]
+  
+    def start_link(options) do
+      {mirror, options} = Keyword.pop(options, :mirror)
+      GenServer.start_link(__MODULE__, mirror, options)
+    end
+  
+    @impl true
+    def init(mirror) do
+      Logger.info("#{__MODULE__}" <> " Starting Up.")
+      mirror = RegistryBackup.load(mirror)
+      {:ok, mirror, {:continue, :sync}}
+    end
+  
+    @impl true
+    def handle_continue(:sync, mirror) do
+      handle_info(:sync, mirror)
+    end
+  
+    @impl true
+    def handle_info(:sync, mirror) do
+      case sync(mirror) do
+        {:ok, %MiniRepo.Mirror{} = new_mirror} ->
+          schedule_sync(new_mirror)
+          {:noreply, new_mirror}
+  
+        _ ->
+          schedule_sync(mirror)
+          {:noreply, mirror}
+      end
+    end
+  
+    defp schedule_sync(mirror) do
+      Process.send_after(self(), :sync, mirror.sync_interval)
+    end
+
+    defp get_storage_path(%{store: {MiniRepo.Store.Local, [root: {_, path}]}} = _mirror) do
+     Path.join(Application.app_dir(:mini_repo), "#{path}/repos/hexpm_mirror/packages")
+    end
+
+    defp get_storage_path(_mirror) do
+        throw("NOT IMPLEMENTED")
+    end
+
+    defp get_packages_on_disk(mirror) do
+        get_storage_path(mirror)
+        |> File.ls
+    end
+  
+    defp sync(mirror) do
+        Logger.debug("Sync/1 Running #{__MODULE__}")
+      config = %{
+        :hex_core.default_config()
+        | repo_name: mirror.upstream_name,
+          repo_url: mirror.upstream_url,
+          repo_public_key: mirror.upstream_public_key,
+          http_user_agent_fragment: user_agent_fragment()
+      }
+  
+      with {:ok, names} when is_list(names) <- sync_names(mirror, config),
+           {:ok, versions} when is_list(versions) <- sync_versions(mirror, config),
+           {:ok, packages_on_disk} <- get_packages_on_disk(mirror) do
+
+        versions =
+          for %{name: name} = map <- versions,
+              name in packages_on_disk,
+              into: %{},
+              do: {name, Map.delete(map, :version)}
+
+        diff = RegistryDiff.diff(mirror.registry, versions)
+        Logger.debug([inspect(__MODULE__), " diff: ", inspect(diff, pretty: true)])
+        created = sync_created_packages(mirror, config, diff)
+        deleted = sync_deleted_packages(mirror, config, diff)
+        updated = sync_releases(mirror, config, diff)
+  
+        mirror =
+          update_in(mirror.registry, fn registry ->
+            registry
+            |> Map.delete(deleted)
+            |> Map.merge(created)
+            |> Map.merge(updated)
+          end)
+  
+        RegistryBackup.save(mirror)
+        {:ok, mirror}
+      end
+    end
+  
+    defp sync_created_packages(mirror, config, diff) do
+      mirror_sync_opts = Keyword.merge(@default_sync_opts, mirror.sync_opts)
+  
+      stream =
+        Task.Supervisor.async_stream_nolink(
+          MiniRepo.TaskSupervisor,
+          diff.packages.created,
+          fn name ->
+            {:ok, releases} = sync_package(mirror, config, name)
+  
+            stream =
+              Task.Supervisor.async_stream_nolink(
+                MiniRepo.TaskSupervisor,
+                releases,
+                fn release ->
+                  :ok = sync_tarball(mirror, config, name, release.version)
+                  release
+                end,
+                mirror_sync_opts
+              )
+  
+            releases = for {:ok, release} <- stream, do: release
+            {name, releases}
+          end,
+          mirror_sync_opts
+        )
+  
+      for {:ok, {name, releases}} <- stream, into: %{} do
+        {name, releases}
+      end
+    end
+  
+    defp sync_deleted_packages(mirror, _config, diff) do
+      for name <- diff.packages.deleted do
+        for %{version: version} <- mirror.registry[name] do
+          store_delete(mirror, ["tarballs", "#{name}-#{version}.tar"])
+        end
+  
+        name
+      end
+    end
+  
+    defp sync_releases(mirror, config, diff) do
+      mirror_sync_opts = Keyword.merge(@default_sync_opts, mirror.sync_opts)
+  
+      stream =
+        Task.Supervisor.async_stream_nolink(
+          MiniRepo.TaskSupervisor,
+          diff.releases,
+          fn {name, map} ->
+            {:ok, releases} = sync_package(mirror, config, name)
+  
+            Task.Supervisor.async_stream_nolink(
+              MiniRepo.TaskSupervisor,
+              map.created,
+              fn version ->
+                :ok = sync_tarball(mirror, config, name, version)
+              end,
+              mirror_sync_opts
+            )
+            |> Stream.run()
+  
+            for version <- map.deleted do
+              store_delete(mirror, ["tarballs", "#{name}-#{version}.tar"])
+            end
+  
+            {name, releases}
+          end,
+          mirror_sync_opts
+        )
+  
+      for {:ok, {name, releases}} <- stream, into: %{} do
+        {name, releases}
+      end
+    end
+  
+    # we don't use this resource for anything, we just copy it (since it's signed by upstream)
+    defp sync_names(mirror, config) do
+      with {:ok, {200, _, names_signed}} <- fetch_names(config),
+           {:ok, names} <- decode_names(mirror, names_signed),
+           :ok <- store_put(mirror, "names", names_signed) do
+        {:ok, names}
+      else
+        other ->
+          Logger.warn("#{inspect(__MODULE__)} sync_names failed: #{inspect(other)}")
+          other
+      end
+    end
+  
+    defp sync_versions(mirror, config) do
+      with {:ok, {200, _, signed}} <- fetch_versions(config),
+           {:ok, versions} <- decode_versions(mirror, signed),
+           :ok <- store_put(mirror, "versions", signed) do
+        {:ok, versions}
+      else
+        other ->
+          Logger.warn("#{inspect(__MODULE__)} sync_versions failed: #{inspect(other)}")
+          other
+      end
+    end
+  
+    defp sync_package(mirror, config, name) do
+      with {:ok, {200, _, signed}} <- fetch_package(config, name),
+           {:ok, package} <- decode_package(mirror, signed, name),
+           :ok <- store_put(mirror, ["packages", name], signed) do
+        {:ok, package}
+      else
+        other ->
+          Logger.warn("#{inspect(__MODULE__)} sync_package failed: #{inspect(other)}")
+          other
+      end
+    end
+  
+    defp sync_tarball(mirror, config, name, version) do
+      with {:ok, {200, _headers, tarball}} <- fetch_tarball(config, name, version),
+           :ok <- store_put(mirror, ["tarballs", "#{name}-#{version}.tar"], tarball) do
+        :ok
+      else
+        other ->
+          Logger.warn("#{inspect(__MODULE__)} sync_tarball failed: #{inspect(other)}")
+          other
+      end
+    end
+  
+    defp fetch_names(config) do
+      Logger.debug("#{inspect(__MODULE__)} fetching names")
+      :hex_http.request(config, :get, config.repo_url <> "/names", %{}, :undefined)
+    end
+  
+    defp fetch_versions(config) do
+      Logger.debug("#{inspect(__MODULE__)} fetching versions")
+      :hex_http.request(config, :get, config.repo_url <> "/versions", %{}, :undefined)
+    end
+  
+    defp fetch_package(config, name) do
+      Logger.debug("#{inspect(__MODULE__)} fetching package #{name}")
+      :hex_http.request(config, :get, config.repo_url <> "/packages/" <> name, %{}, :undefined)
+    end
+  
+    defp fetch_tarball(config, name, version) do
+      Logger.debug("#{inspect(__MODULE__)} fetching tarball #{name}-#{version}.tar")
+      :hex_repo.get_tarball(config, name, version)
+    end
+  
+    defp decode_names(mirror, body) do
+      {:ok, payload} = decode_and_verify_signed(body, mirror)
+      :hex_registry.decode_names(payload, mirror.upstream_name)
+    end
+  
+    defp decode_versions(mirror, body) do
+      {:ok, payload} = decode_and_verify_signed(body, mirror)
+      :hex_registry.decode_versions(payload, mirror.upstream_name)
+    end
+  
+    defp decode_package(mirror, body, name) do
+      {:ok, payload} = decode_and_verify_signed(body, mirror)
+      :hex_registry.decode_package(payload, mirror.upstream_name, name)
+    end
+  
+    defp decode_and_verify_signed(body, mirror) do
+      :hex_registry.decode_and_verify_signed(:zlib.gunzip(body), mirror.upstream_public_key)
+    end
+  
+    defp user_agent_fragment() do
+      {:ok, vsn} = :application.get_key(:mini_repo, :vsn)
+      "mini_repo/#{vsn}"
+    end
+  
+    defp store_put(mirror, path, contents) do
+      MiniRepo.Store.put(mirror.store, ["repos", mirror.name] ++ List.wrap(path), contents)
+    end
+  
+    defp store_delete(repository, name) do
+      MiniRepo.Store.delete(repository.store, name)
+    end
+  end
+  

--- a/lib/mini_repo/mirror/server_on_demand.ex
+++ b/lib/mini_repo/mirror/server_on_demand.ex
@@ -41,14 +41,6 @@ defmodule MiniRepo.Mirror.ServerOnDemand do
     Process.send_after(self(), :sync, mirror.sync_interval)
   end
 
-  defp get_storage_path(%{store: {MiniRepo.Store.Local, [root: {_, path}]}} = _mirror) do
-    Path.join(Application.app_dir(:mini_repo), "#{path}/repos/hexpm_mirror/packages")
-  end
-
-  defp get_storage_path(_mirror) do
-    throw("NOT IMPLEMENTED")
-  end
-
   defp get_config_from_mirror(mirror) do
     %{
       :hex_core.default_config()

--- a/lib/mini_repo/mirror_on_demand.ex
+++ b/lib/mini_repo/mirror_on_demand.ex
@@ -1,0 +1,69 @@
+defmodule MiniRepo.MirrorOnDemand do
+  @moduledoc """
+  A mirror is a read-only repository that is kept in sync with another (upstream) repository.
+
+  ## Fields
+
+    * `:name` - mirror name
+
+    * `:upstream_name` - the name of the repository we are mirroring
+
+    * `:upstream_url` - the url of the repository we are mirroring
+
+    * `:upstream_public_key` - the public key of the repository we are mirroring
+
+    * `:store` - repository storage
+
+    * `:sync_opts` - options used for syncing packages and releases concurrently
+       (using `Task.Supervisor.async_stream_nolink/4`). Provided options will be merged with the
+       default `[ordered: false]`.
+
+    * `:sync_interval` - how often to check mirrored repository for changes in milliseconds.
+
+    * `:only` - if set, it is an allowed list of packages to mirror. If not set, we mirror all
+       available packages.
+
+       When using `:only` option, you need to manually make sure that all of package's
+       dependencies are included in the allowed list.
+
+       Note, this mirror works by copying `/names` and `versions` resources from upstream.
+       Thus, even though these resources may list a given package, if it's not in the allowed list it won't
+       be stored in the mirror. An alternative mirror implementation could have `/names` and `/versions`
+       resources only contain packages that the mirror actually has, but these resources would have
+       to be signed with mirror's private key.
+
+  ## Usage
+
+  To set up a mirror, add it as any other repository:
+
+      config :mini_repo,
+        repositories: [
+          a_mirror: [
+            upstream_name: "some_mirror",
+            upstream_url: "http://some_url",
+            # ...
+          ]
+        ]
+
+  """
+
+  @enforce_keys [
+    :name,
+    :upstream_name,
+    :upstream_url,
+    :upstream_public_key,
+    :sync_interval,
+    :store
+  ]
+  defstruct [
+    :name,
+    :upstream_name,
+    :upstream_url,
+    :upstream_public_key,
+    :sync_interval,
+    :on_demand,
+    :store,
+    registry: %{},
+    sync_opts: []
+  ]
+end


### PR DESCRIPTION
Ok guys, here is my first attempt at this. Definitely hoping to get some feedback. I am sure there is a better way to do this. 

Note: 
The new config option: on_demand
This will get mapped to a new struct (mirror_on_demand) which will determine which version of Mirror.Server gets started. 


Notable obstacles I had to overcome: When to call RegistryBackup.save(mirror).  It made sense to me to only call this after a tarball has been saved and put into the registry.  This leads to checking the registry twice..Once when the packages is requested, and once when the tarball is requested. Both of these checks will be false for the first time a package version is requested..But future requests for the same version will show the package exists in the registry. 

You may have a better idea for this flow..I thought about checking  if the package file exists on the disk, but I didn't know how that would react if s3 storage is being used.  

Let me know your thoughts.  I wanted to get your review to see if this is the right direction. 
