### PR TITLE
Add an option to extract docs

### DIFF
--- a/lib/mini_repo/repository.ex
+++ b/lib/mini_repo/repository.ex
@@ -3,5 +3,5 @@ defmodule MiniRepo.Repository do
 
   @derive {Inspect, only: [:name, :public_key, :store, :registry]}
   @enforce_keys [:name, :public_key, :private_key, :store]
-  defstruct [:name, :public_key, :private_key, :store, registry: %{}]
+  defstruct [:name, :public_key, :private_key, :store, registry: %{}, extract_docs: false]
 end


### PR DESCRIPTION
This PR adds a new option, `extract_docs`, which tells to *mini_repo* to extract the docs into the configured storage. That feature allows browsing the package documentation directly from the *mini_repo* instance instead of downloading the documentation tar of each package/version.

Please close or let me know if this PR does not meet the contributing guidelines. I'm happy leaving this PR not merged but at least documented here.