### PR TITLE
fix: use hex_core dep from hex.pm

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule MiniRepo.MixProject do
 
   defp deps() do
     [
-      {:hex_core, "~> 0.6.0", path: "../hex_core"},
+      {:hex_core, "~> 0.6.0"},
 
       # plug
       {:plug, "~> 1.0"},


### PR DESCRIPTION
Unfortunately, the current master is broken because the `hex_core` dependency has to be located on the local file system (which it is not in most cases). 

```elixir
{:hex_core, "~> 0.6.0", path: "../hex_core"}
```

This PR fixes the mix.exs file to get `hex_core` from hex.pm.